### PR TITLE
Add comprehensive GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,106 @@
+name: Bug Report
+description: Report a bug or issue with mcpcap
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out this form as completely as possible.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is.
+      placeholder: Describe the bug...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Run mcpcap with...
+        2. Analyze PCAP file...
+        3. See error...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected to happen.
+      placeholder: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened instead?
+      placeholder: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: pcap-info
+    attributes:
+      label: PCAP File Information
+      description: Information about the PCAP file that caused the issue (if applicable)
+      placeholder: |
+        - File size: 
+        - Protocols present: 
+        - Capture tool: 
+        - Any sensitive data removed: Yes/No
+    validations:
+      required: false
+
+  - type: dropdown
+    id: modules
+    attributes:
+      label: Affected Modules
+      description: Which mcpcap modules are affected?
+      multiple: true
+      options:
+        - DNS
+        - DHCP
+        - ICMP
+        - All modules
+        - Unknown
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Information about your environment
+      placeholder: |
+        - mcpcap version: 
+        - Python version: 
+        - Operating system: 
+        - Installation method: pip/git/other
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error Logs
+      description: If applicable, add any error messages or logs
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem here
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://docs.mcpcap.ai
+    about: Check the documentation for usage guides and API reference
+  - name: Discussions
+    url: https://github.com/mcpcap/mcpcap/discussions
+    about: Ask questions and discuss ideas with the community

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,104 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for mcpcap
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a new feature! Please describe your idea clearly.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Feature Summary
+      description: A brief summary of the feature you'd like to see
+      placeholder: What feature would you like to see added?
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve?
+      placeholder: |
+        Is your feature request related to a problem? Please describe.
+        A clear and concise description of what the problem is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like
+      placeholder: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Feature Category
+      description: What type of feature is this?
+      options:
+        - New protocol support
+        - Analysis enhancement
+        - Performance improvement
+        - User interface
+        - Documentation
+        - Testing
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority Level
+      description: How important is this feature to you?
+      options:
+        - Low - Nice to have
+        - Medium - Would be helpful
+        - High - Important for my use case
+        - Critical - Blocking my work
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternative Solutions
+      description: Describe any alternative solutions or features you've considered
+      placeholder: What alternatives have you considered?
+    validations:
+      required: false
+
+  - type: textarea
+    id: use-cases
+    attributes:
+      label: Use Cases
+      description: Describe specific use cases where this feature would be valuable
+      placeholder: |
+        - Use case 1: ...
+        - Use case 2: ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Implementation Ideas
+      description: If you have ideas about how this could be implemented, share them here
+      placeholder: Any thoughts on how this could be implemented?
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context, screenshots, or examples about the feature request
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/module_request.yml
+++ b/.github/ISSUE_TEMPLATE/module_request.yml
@@ -1,0 +1,123 @@
+name: Protocol Module Request
+description: Request support for a new network protocol analysis module
+title: "[Module] Add support for [PROTOCOL_NAME]"
+labels: ["enhancement", "module", "protocol"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for requesting a new protocol module! This helps us prioritize which protocols to support next.
+
+  - type: input
+    id: protocol-name
+    attributes:
+      label: Protocol Name
+      description: What protocol would you like mcpcap to support?
+      placeholder: e.g., HTTP, FTP, SSH, etc.
+    validations:
+      required: true
+
+  - type: textarea
+    id: protocol-description
+    attributes:
+      label: Protocol Description
+      description: Brief description of the protocol and its purpose
+      placeholder: What does this protocol do? What is it used for?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: protocol-layer
+    attributes:
+      label: OSI Layer
+      description: Which OSI layer does this protocol primarily operate at?
+      options:
+        - Layer 2 - Data Link
+        - Layer 3 - Network  
+        - Layer 4 - Transport
+        - Layer 5 - Session
+        - Layer 6 - Presentation
+        - Layer 7 - Application
+        - Multiple layers
+        - Unknown/Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-cases
+    attributes:
+      label: Use Cases
+      description: What specific analysis would you want to perform on this protocol?
+      placeholder: |
+        - Security analysis: ...
+        - Performance monitoring: ...
+        - Troubleshooting: ...
+        - Compliance: ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: analysis-goals
+    attributes:
+      label: Analysis Goals
+      description: What specific information should the module extract or analyze?
+      placeholder: |
+        - Packet counts and sizes
+        - Connection patterns
+        - Error rates
+        - Specific protocol fields
+        - Security indicators
+    validations:
+      required: true
+
+  - type: input
+    id: rfc-standards
+    attributes:
+      label: RFC or Standards
+      description: Are there RFC documents or standards that define this protocol?
+      placeholder: e.g., RFC 793, IEEE 802.11, etc.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority Level
+      description: How important is this protocol support to your work?
+      options:
+        - Low - Nice to have
+        - Medium - Would be helpful
+        - High - Important for my use case
+        - Critical - Blocking my work
+    validations:
+      required: true
+
+  - type: textarea
+    id: sample-data
+    attributes:
+      label: Sample Data Availability
+      description: Do you have sample PCAP files with this protocol that could help with development?
+      placeholder: |
+        - Yes, I can provide sanitized samples
+        - Yes, but they contain sensitive data
+        - No, but I can generate some
+        - No sample data available
+    validations:
+      required: false
+
+  - type: textarea
+    id: existing-tools
+    attributes:
+      label: Existing Analysis Tools
+      description: Are there existing tools that analyze this protocol? How would mcpcap be different/better?
+      placeholder: What tools currently exist for analyzing this protocol?
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other information that would help with implementing this module
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Add bug report template with PCAP-specific fields and module selection
- Add feature request template with priority levels and use cases
- Add protocol module request template for new protocol support
- Add config to disable blank issues and provide documentation links

## Changes
- **Bug Report Template**: Structured form with PCAP file info, affected modules, environment details
- **Feature Request Template**: Includes problem statement, proposed solution, priority levels  
- **Module Request Template**: Specifically for requesting new protocol analysis modules
- **Configuration**: Disables blank issues, provides links to docs.mcpcap.ai and discussions

## Benefits
- Standardizes issue reporting process
- Gathers all necessary information upfront
- Helps with issue triage and categorization
- Guides users to provide relevant technical details

## Test plan
- [ ] Verify templates appear correctly in GitHub issue creation interface
- [ ] Test each template form renders properly
- [ ] Confirm documentation links work correctly