### PR TITLE
Add capinfos module to gather metadata from a pcap

### DIFF
--- a/src/mcpcap/cli.py
+++ b/src/mcpcap/cli.py
@@ -28,8 +28,8 @@ def main():
     # Analysis options
     parser.add_argument(
         "--modules",
-        help="Comma-separated list of modules to load (default: dns,dhcp,icmp)",
-        default="dns,dhcp,icmp",
+        help="Comma-separated list of modules to load (default: dns,dhcp,icmp,capinfos)",
+        default="dns,dhcp,icmp,capinfos",
     )
     parser.add_argument(
         "--max-packets",
@@ -41,7 +41,11 @@ def main():
 
     try:
         # Parse modules
-        modules = args.modules.split(",") if args.modules else ["dns", "dhcp", "icmp"]
+        modules = (
+            args.modules.split(",")
+            if args.modules
+            else ["dns", "dhcp", "icmp", "capinfos"]
+        )
 
         # Initialize configuration
         config = Config(

--- a/src/mcpcap/core/server.py
+++ b/src/mcpcap/core/server.py
@@ -2,6 +2,7 @@
 
 from fastmcp import FastMCP
 
+from ..modules.capinfos import CapInfosModule
 from ..modules.dhcp import DHCPModule
 from ..modules.dns import DNSModule
 from ..modules.icmp import ICMPModule
@@ -29,6 +30,8 @@ class MCPServer:
             self.modules["dhcp"] = DHCPModule(config)
         if "icmp" in self.config.modules:
             self.modules["icmp"] = ICMPModule(config)
+        if "capinfos" in self.config.modules:
+            self.modules["capinfos"] = CapInfosModule(config)
 
         # Register tools
         self._register_tools()
@@ -47,6 +50,8 @@ class MCPServer:
                 self.mcp.tool(module.analyze_dhcp_packets)
             elif module_name == "icmp":
                 self.mcp.tool(module.analyze_icmp_packets)
+            elif module_name == "capinfos":
+                self.mcp.tool(module.analyze_capinfos)
 
     def run(self) -> None:
         """Start the MCP server."""

--- a/src/mcpcap/modules/capinfos.py
+++ b/src/mcpcap/modules/capinfos.py
@@ -1,0 +1,117 @@
+"""CapInfos analysis module."""
+
+import os
+from typing import Any
+
+from fastmcp import FastMCP
+from scapy.all import PcapReader, rdpcap
+
+from .base import BaseModule
+
+
+class CapInfosModule(BaseModule):
+    """Module for gathering metadata about capture files."""
+
+    @property
+    def protocol_name(self) -> str:
+        """Return the name of the protocol this module analyzes."""
+        return "CapInfos"
+
+    def analyze_capinfos(self, pcap_file: str) -> dict[str, Any]:
+        """
+        Return metadata from a PCAP file.
+
+        Args:
+            pcap_file: Path to local PCAP file or HTTP URL to remote PCAP file
+
+        Returns:
+            A structured dictionary containing metadata
+        """
+        return self.analyze_packets(pcap_file)
+
+    def _analyze_protocol_file(self, pcap_file: str) -> dict[str, Any]:
+        """Perform the actual information gathering on a local PCAP file."""
+        try:
+            packets = rdpcap(pcap_file)
+
+            # Generate statistics
+            stats = self._generate_statistics(packets)
+
+            results = {
+                "file_size_bytes": os.path.getsize(pcap_file),
+                "filename": os.path.basename(pcap_file),
+                "file_encapsulation": self._detect_linktype(pcap_file),
+            }
+
+            return results | stats
+
+        except Exception as e:
+            return {
+                "error": f"Error reading PCAP file '{pcap_file}': {str(e)}",
+                "file": pcap_file,
+            }
+
+    def _detect_linktype(self, path: str) -> str:
+        """Detect the linktype and try to map it to a human-readable encapsulation type.
+
+        Args:
+            path: Path to the packet capture
+
+        Returns:
+            Detected link-layer header (linktype)
+
+        """
+        # mapping based on pcap-linktype(7) and https://github.com/wireshark/wireshark/blob/master/wiretap/wtap.c#L656
+        LINKTYPE_MAP = {
+            1: "Ethernet",
+            101: "Raw IP",
+            105: "IEEE 802.11 Wireless LAN",
+            113: "Linux cooked-mode capture v1",
+            228: "Raw IPv4",
+            229: "Raw IPv6",
+            276: "Linux cooked-mode capture v2",
+        }
+        try:
+            with PcapReader(path) as reader:
+                linktype = getattr(reader, "linktype", None)
+        except Exception:
+            linktype = None
+
+        return LINKTYPE_MAP.get(
+            linktype, f"Unknown ({linktype})" if linktype else "Unknown"
+        )
+
+    def _generate_statistics(self, packet_details: list) -> dict[str, Any]:
+        """Return metadata about the capture file, similar to capinfos(1) utility."""
+        if not packet_details:
+            return {"error": "No packets found"}
+
+        packet_count = len(packet_details)
+        data_size = sum(len(pkt) for pkt in packet_details)
+        first_time = float(packet_details[0].time)
+        last_time = float(packet_details[-1].time)
+        duration = max(last_time - first_time, 0.000001)
+        data_byte_rate = data_size / duration if duration > 0 else 0
+        data_bit_rate = (data_size * 8) / duration if duration > 0 else 0
+        avg_packet_size = data_size / packet_count if packet_count > 0 else 0
+        avg_packet_rate = packet_count / duration if duration > 0 else 0
+
+        return {
+            "packet_count": packet_count,
+            "data_size_bytes": data_size,
+            "capture_duration_seconds": duration,
+            "first_packet_time": first_time,
+            "last_packet_time": last_time,
+            "data_rate_bytes": data_byte_rate,
+            "data_rate_bits": data_bit_rate,
+            "average_packet_size_bytes": avg_packet_size,
+            "average_packet_rate": avg_packet_rate,
+        }
+
+    def setup_prompts(self, mcp: FastMCP) -> None:
+        """Set up prompts for the MCP server.
+
+        Args:
+            mcp: FastMCP server instance
+        """
+        pass

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,7 @@ class TestCLI:
 
         # Verify behavior
         mock_config.assert_called_once_with(
-            modules=["dns", "dhcp", "icmp"],
+            modules=["dns", "dhcp", "icmp", "capinfos"],
             max_packets=None,
         )
         mock_server.assert_called_once_with(config_instance)

--- a/tests/test_modules/test_capinfos.py
+++ b/tests/test_modules/test_capinfos.py
@@ -1,0 +1,108 @@
+"""Tests for CapInfos module."""
+
+import tempfile
+from unittest.mock import Mock
+
+from scapy.all import IP, TCP, Raw, wrpcap
+
+from mcpcap.core.config import Config
+from mcpcap.modules.capinfos import CapInfosModule
+
+
+class TestCapInfosModule:
+    """Test CapInfos module functionality."""
+
+    def test_protocol_name(self):
+        """Test protocol name property."""
+        config = Mock()
+        module = CapInfosModule(config)
+        assert module.protocol_name == "CapInfos"
+
+    def test_analyze_capinfos_file_not_found(self):
+        """Test capinfos when file doesn't exist."""
+        config = Config()
+        module = CapInfosModule(config)
+
+        result = module.analyze_capinfos("/nonexistent/file.pcap")
+
+        assert "error" in result
+        assert "not found" in result["error"]
+        assert result["pcap_file"] == "/nonexistent/file.pcap"
+
+    def test_analyze_capinfos(self):
+        """Test capinfos with no packets."""
+
+        # Write some packets to the temp file
+        packets = [
+            IP(src="192.168.0.1", dst="192.168.0.2")
+            / TCP(sport=1234, dport=80)
+            / Raw(load=b"GET / HTTP/1.1"),
+            IP(src="192.168.0.2", dst="192.168.0.1")
+            / TCP(sport=80, dport=1234)
+            / Raw(load=b"HTTP/1.1 200 OK"),
+        ]
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pcap") as tmp_file:
+            wrpcap(tmp_file.name, packets)
+            temp_path = tmp_file.name
+
+        try:
+            config = Config()
+            module = CapInfosModule(config)
+            result = module.analyze_capinfos(temp_path)
+
+            # Verify results from _generate_statistics
+            assert "packet_count" in result
+            assert "data_size_bytes" in result
+            assert "capture_duration_seconds" in result
+            assert "first_packet_time" in result
+            assert "last_packet_time" in result
+            assert "data_rate_bytes" in result
+            assert "data_rate_bits" in result
+            assert "average_packet_size_bytes" in result
+            assert "average_packet_rate" in result
+
+            # Verify file-only details
+            assert "file_size_bytes" in result
+            assert "filename" in result
+            assert "file_encapsulation" in result
+
+            # verify actual file + packet details
+            assert result["file_encapsulation"] == "Raw IPv4"
+            assert result["packet_count"] == 2
+            assert result["average_packet_size_bytes"] == 54.50
+
+        finally:
+            import os
+
+            os.unlink(temp_path)
+
+    def test_analyze_capinfos_unknown_linktype(self):
+        """Test capinfos with no packets."""
+
+        # Write some packets to the temp file
+        packets = [
+            IP(src="192.168.0.1", dst="192.168.0.2")
+            / TCP(sport=1234, dport=80)
+            / Raw(load=b"GET / HTTP/1.1"),
+        ]
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pcap") as tmp_file:
+            wrpcap(tmp_file.name, packets, linktype=1024)
+            temp_path = tmp_file.name
+
+        try:
+            config = Config()
+            module = CapInfosModule(config)
+            result = module.analyze_capinfos(temp_path)
+
+            # Verify file-only details
+            assert "file_encapsulation" in result
+
+            # verify actual file + packet details
+            assert result["file_encapsulation"] == "Unknown (1024)"
+
+        finally:
+            import os
+
+            os.unlink(temp_path)


### PR DESCRIPTION
## Description
Add a `capinfos(1)`-like module to gather protocol-agnostic metadata from a packet capture.

## Type of Change
- [ ] Bug fix
- [x] New feature (new protocol module)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe)

## Testing
- [x] Tests pass locally
- [x] Added new tests for new functionality
- [ ] Coverage remains >95% $\color{#f00}{\textsf{(currently 86\\%)}}$

## Documentation
- [ ] Updated relevant documentation
- [ ] Added examples
- [ ] Docstrings updated

## Checklist
- [x] Code follows style guidelines
- [ ] Self-review completed
- [x] Tests added/updated
- [ ] Documentation updated