### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 ![mcpcap logo](https://raw.githubusercontent.com/mcpcap/mcpcap/main/readme-assets/mcpcap-logo.png)
 
+<a href="https://glama.ai/mcp/servers/@danohn/mcpcap">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@danohn/mcpcap/badge" alt="mcpcap MCP server" />
+</a>
+
 A modular Python MCP (Model Context Protocol) Server for analyzing PCAP files. mcpcap enables LLMs to read and analyze network packet captures with protocol-specific analysis tools that accept local file paths or remote URLs as parameters (no file uploads - provide the path or URL to your PCAP file).
 
 ## Overview


### PR DESCRIPTION
This PR adds a badge for the [mcpcap](https://glama.ai/mcp/servers/@danohn/mcpcap) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@danohn/mcpcap">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@danohn/mcpcap/badge" alt="mcpcap MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.