### PR TITLE
Add Docker distribution, Compose workflows, and GHCR attestation support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     permissions:
       contents: write  # Required for creating releases
       id-token: write  # Required for PyPI trusted publishing
+      attestations: write  # Required for GitHub build provenance attestations
+      artifact-metadata: write  # Enables linked artifact records for registry-pushed attestations
       packages: write  # Required for publishing to GHCR
 
     steps:
@@ -123,6 +125,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and publish Docker image
+      id: docker_build
       uses: docker/build-push-action@v6
       with:
         context: .
@@ -140,6 +143,13 @@ jobs:
           org.opencontainers.image.version=${{ steps.docker_meta.outputs.version }}
           org.opencontainers.image.revision=${{ github.sha }}
           org.opencontainers.image.created=${{ steps.docker_meta.outputs.created }}
+
+    - name: Generate Docker build attestation
+      uses: actions/attest-build-provenance@v3
+      with:
+        subject-name: ghcr.io/mcpcap/mcpcap
+        subject-digest: ${{ steps.docker_build.outputs.digest }}
+        push-to-registry: true
 
     # -------- MCP Registry: best practice - align server.json version ----------
     - name: Update server.json version to tag


### PR DESCRIPTION
## Summary
- Add a production `Dockerfile` and `.dockerignore` for running `mcpcap` in containers
- Publish versioned and `latest` GHCR images from the release workflow, including build provenance attestation
- Add Docker CI coverage plus end-user and developer Compose workflows
- Update README, docs, and website content to document Docker usage and container-visible PCAP paths
- Replace stale sample capture URLs in docs with working hosted examples

## Testing
- `docker build --build-arg MCPPCAP_VERSION=0.0.0.dev0 --build-arg VCS_REF=local --build-arg BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) -t mcpcap:test .`
- `docker run --rm -i mcpcap:test --help`
- `docker compose up --build -d`
- `curl http://127.0.0.1:8080/mcp` returned expected `406 Not Acceptable`
- `docker compose down`