### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: Test
 
+permissions:
+  contents: read
+  packages: read
+
 on:
   push:
     branches: [ main, dev ]


### PR DESCRIPTION
Potential fix for [https://github.com/mcpcap/mcpcap/security/code-scanning/3](https://github.com/mcpcap/mcpcap/security/code-scanning/3)

In general, fix this by adding an explicit `permissions` block that grants only the minimal scopes needed. This can be done at the workflow level (applies to all jobs) or per job (for finer-grained control). Since all three jobs in this workflow only read code and do not push or modify repository state, they can safely run with `contents: read` and `packages: read`.

The best fix here, without changing existing functionality, is to add a workflow-level `permissions` block near the top (after `name:` and before `on:`). This will restrict the `GITHUB_TOKEN` for all jobs (`test`, `docker`, and `check-version`) to read-only repository contents and packages, which is sufficient for `actions/checkout` and typical build/test operations. No imports or additional methods are needed; it’s a pure YAML configuration change in `.github/workflows/test.yml`, affecting lines after `1: name: Test` and before `3: on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
